### PR TITLE
initial implementation of MARC.to_xml() #45

### DIFF
--- a/dlx/marc.py
+++ b/dlx/marc.py
@@ -10,6 +10,9 @@ from dlx.db import DB
 from dlx.query import jmarc as Q
 from dlx.query import jfile as FQ
 
+from xml.etree import ElementTree as XML
+#from lxml.etree import tostring as write_xml
+
 ### Record classes
      
 class MARC(object):
@@ -762,6 +765,7 @@ class MARC(object):
         return string
     
     def to_str(self,*tags):
+        # non-standard format intended to be human readable 
         string = ''
         
         for f in self.get_fields(*tags): 
@@ -779,8 +783,28 @@ class MARC(object):
         
         return string
             
-    def to_xml(self):
-        pass
+    def to_xml(self,*tags):
+        # todo: reimplement with `xml.dom` or `lxml` to enable pretty-printing
+        
+        root = XML.Element('record')
+        
+        for field in self.get_fields(*tags):
+            if isinstance(field,Controlfield):
+                node = XML.SubElement(root,'controlfield')
+                node.set('tag',field.tag)
+                node.text = field.value
+            else:
+                node = XML.SubElement(root,'datafield')
+                node.set('tag',field.tag)
+                node.set('ind1',field.ind1)
+                node.set('ind2',field.ind2)
+                
+                for sub in field.subfields:
+                    subnode = XML.SubElement(node,'subfield')
+                    subnode.set('code',sub.code)
+                    subnode.text = sub.value
+                
+        return XML.tostring(root,'utf-8')
         
     #### de-serializations
     # these formats don't fully support linked values.

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -646,10 +646,17 @@ class Set(TestCase):
         self.assertEqual(bib.get_values('500','a'), ['desc', 'desc'])
         
 class Serialization(TestCase):
-    pass
-    #def setUp(self):
-        #DB.connect('mongodb://.../?authSource=dummy',mock=True)
-        #Bib(Data.jbib).commit()
+    def setUp(self):
+        DB.connect('mongodb://.../?authSource=dummy',mock=True)
+        Bib(Data.jbib).commit()
+        
+    def test_to_xml(self):
+        bib = Bib.match_id(999)
+         
+        self.assertEqual(
+            bib.to_xml(),
+            b'<record><controlfield tag="000">leader</controlfield><controlfield tag="008">controlfield</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">This</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">description</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">another description</subfield><subfield code="a">repeated subfield</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">N/A</subfield></datafield><datafield ind1=" " ind2=" " tag="710"><subfield code="a">N/A</subfield></datafield></record>'
+        )
         
     #def test_to_mij(self):
     #    pass


### PR DESCRIPTION
Lacks pretty-printing