### PR TITLE
Add dbname argument to scripts

### DIFF
--- a/dlx/scripts/auth_merge.py
+++ b/dlx/scripts/auth_merge.py
@@ -7,6 +7,7 @@ from dlx.marc import Auth
 def get_args(**kwargs):
     parser = ArgumentParser()
     parser.add_argument('--connect', required=True)
+    parser.add_argument('--dbname')
     parser.add_argument('--gaining_id', required=True, type=int)
     parser.add_argument('--losing_id', required=True, type=int)
     parser.add_argument('--user', required=True)
@@ -24,7 +25,10 @@ def run(**kwargs):
     args = get_args(**kwargs)
     
     if not DB.connected:
-        DB.connect(args.connect)
+        if args.dbname:
+            DB.connect(args.connect, database=args.dbname)
+        else:
+            DB.connect(args.connect)
 
     print(f'Merging auth {args.losing_id} into {args.gaining_id}')
     started = time()

--- a/dlx/scripts/build_logical_fields.py
+++ b/dlx/scripts/build_logical_fields.py
@@ -13,6 +13,7 @@ from dlx.util import Tokenizer
 
 parser = ArgumentParser()
 parser.add_argument('--connect', required=True)
+parser.add_argument('--dbname')
 parser.add_argument('--type', required=True, choices=['bib', 'auth'])
 parser.add_argument('--start', default=0)
   
@@ -20,7 +21,10 @@ def run():
     args = parser.parse_args()
     
     if not DB.connected:
-        DB.connect(args.connect)
+        if args.dbname:
+            DB.connect(args.connect, database=args.dbname)
+        else:
+            DB.connect(args.connect)
 
     build_logical_fields(args)
     #build_auth_controlled_logical_fields(args) # disabled

--- a/dlx/scripts/build_text_collections.py
+++ b/dlx/scripts/build_text_collections.py
@@ -15,12 +15,16 @@ from dlx.util import Tokenizer
 
 parser = ArgumentParser()
 parser.add_argument('--connect', required=True)
+parser.add_argument('--dbname')
 parser.add_argument('--type', required=True, choices=['bib', 'auth'])
 parser.add_argument('--start', default=0)
 
 def run():
     args = parser.parse_args()
-    DB.connect(args.connect)
+    if args.dbname:
+        DB.connect(args.connect, database=args.dbname)
+    else:
+        DB.connect(args.connect)
     cls = BibSet if args.type == 'bib' else AuthSet
 
     start = int(args.start)

--- a/dlx/scripts/clear_incrementers.py
+++ b/dlx/scripts/clear_incrementers.py
@@ -6,10 +6,14 @@ from dlx import DB
 
 parser = ArgumentParser()
 parser.add_argument('--connect', required=True)
+parser.add_argument('--dbname')
 
 def run():
     args = parser.parse_args()
     
-    DB.connect(args.connect)
+    if args.dbname:
+        DB.connect(args.connect, database=args.dbname)
+    else:
+        DB.connect(args.connect)
     DB.handle['bib_id_counter'].drop()
     DB.handle['auth_id_counter'].drop()

--- a/dlx/scripts/excel_marc.py
+++ b/dlx/scripts/excel_marc.py
@@ -7,6 +7,7 @@ from dlx.marc import BibSet, AuthSet
 
 parser = ArgumentParser()
 parser.add_argument('--connect')
+parser.add_argument('--dbname')
 parser.add_argument('--file', required=True)
 parser.add_argument('--type', required=True, choices=['bib', 'auth'])
 parser.add_argument('--format', required=True, choices=['mrc', 'mrk', 'xml'])
@@ -19,7 +20,10 @@ parser.add_argument('--defaults')
 def run():
     args = parser.parse_args()
 
-    DB.connect(args.connect)
+    if args.dbname:
+        DB.connect(args.connect, database=args.dbname)
+    else:
+        DB.connect(args.connect)
     Cls = BibSet if args.type == 'bib' else AuthSet
 
     data = Cls.from_excel(args.file, auth_control=False, auth_flag=True, field_check=args.check)

--- a/dlx/scripts/init_indexes.py
+++ b/dlx/scripts/init_indexes.py
@@ -8,11 +8,15 @@ from pymongo.collation import Collation
 
 parser = ArgumentParser()
 parser.add_argument('--connect')
+parser.add_argument('--dbname')
 parser.add_argument('--verbose', action='store_true')
 
 def run():
     args = parser.parse_args()
-    DB.connect(args.connect)
+    if args.dbname:
+        DB.connect(args.connect, database=args.dbname)
+    else:
+        DB.connect(args.connect)
 
     indexes = []
 


### PR DESCRIPTION
The new Atlas connect strings don't conform to the previous assumptions about which database to use, so we need to update the scripts to allow a database name to be specified. This builds on the previous commits.