### PR TITLE
Capture missing history

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -822,8 +822,15 @@ class Marc(object):
             record_history = history_collection.find_one({'_id': self.id})
 
             if record_history:
-                record_history.setdefault('history', []) # record may not have history if migrated from another db
-                record_history['history'].append(data)
+                # capture previous state if record originated in another db
+                if record_history.get('history') is None:
+                    if previous_state:
+                        previous_state['user'] = 'system import'
+                        record_history['history'] = [previous_state, data]
+                    else:
+                        record_history['history'] = [data]
+                else:
+                    record_history['history'].append(data)
             else:
                 record_history = SON()
                 record_history['_id'] = self.id
@@ -831,7 +838,12 @@ class Marc(object):
                 if new_record:
                     record_history['created'] = SON({'user': user, 'time': datetime.utcnow()})
 
-                record_history['history'] = [data]
+                # capture previous state if record originated in another db
+                if previous_state:
+                    previous_state['user'] = 'system import'
+                    record_history['history'] = [previous_state, data]
+                else:
+                    record_history['history'] = [data]
 
             history_collection.replace_one({'_id': self.id}, record_history, upsert=True)
 


### PR DESCRIPTION
Save a copy of the previous state in the history if it doesn't already exist, for example if the data was imported from another source