### PR TITLE
Fix/optimize field '*' search

### DIFF
--- a/dlx/marc/query.py
+++ b/dlx/marc/query.py
@@ -59,12 +59,18 @@ class Query():
                 else:
                     return Regex(string[1:-1])
             elif '*' in string:
+                if string == '*':
+                    # special string for checking if field exists
+                    return string
+
+                # convert to regex
                 string = string.replace('(', r'\(')
                 string = string.replace(')', r'\)')
                 string = string.replace('[', r'\]')
                 string = string.replace(']', r'\[')
                 return Regex('^' + string.replace('*', '.*?') + '$')
             else:
+                # do nothing
                 return string
 
         def add_quotes(string):
@@ -91,6 +97,10 @@ class Query():
             if match:
                 tag, ind1, ind2, code, value = match.group(1, 2, 3, 4, 5)
                 value = process_string(value)
+
+                # exists
+                if value == '*':
+                    return Raw({f'{tag}.subfields': {'$elemMatch': {'code': code}}})
 
                 # regex
                 if isinstance(value, Regex):
@@ -162,6 +172,10 @@ class Query():
                         raise InvalidQueryString(f'ID must be a number')
                 elif tag[:2] == '00':
                     return Raw({tag: value}, record_type=record_type)
+
+                # exists
+                if value == '*':
+                    return Raw({tag: {'$exists': True}})
 
                 # regex
                 if isinstance(value, Regex):


### PR DESCRIPTION
For query strings in the form `999:*` or `999__a:*`, optimize the query to use MDB $exists operator instead of regex

Addresses https://github.com/dag-hammarskjold-library/dlx-rest/issues/1092