### PR TITLE
Tokenizer only splits on specified chars

### DIFF
--- a/dlx/util.py
+++ b/dlx/util.py
@@ -981,7 +981,7 @@ class Tokenizer:
     
     @classmethod
     def split_words(cls, string):
-        return re.compile(r'\w+').findall(string)
+        return re.compile(r'[^\u0020-\u002f\u2018\u2019\u201c\u201d]+').findall(string)
         
     @classmethod
     def asciify(cls, string):
@@ -1008,10 +1008,13 @@ class Tokenizer:
 
     @classmethod
     def scrub(cls, string):
-        #string = re.sub(r"['‘’]", '', string) # apostrophes
-        return re.sub(r'\W+', ' ', Tokenizer.asciify(string.upper()).lower()).strip()
+        '''Convert to lowercase and remove puncuation from a string'''
+        
+        # replace ascii punctuation with space
+        return re.sub(r'[\u0020-\u002f\u2018\u2019\u201c\u201d]+', ' ', Tokenizer.asciify(string.upper()).lower()).strip()
 
     @classmethod
     def tokenize(cls, string):
-        return [Tokenizer.stem(x) for x in Tokenizer.split_words(Tokenizer.asciify(string))]
+        '''Split a string into an array of stemmed words'''
 
+        return [Tokenizer.stem(x) for x in Tokenizer.split_words(Tokenizer.asciify(string))]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -35,5 +35,10 @@ class TestTable(TestCase):
 def test_tokenizer():
     from dlx.util import Tokenizer
 
-    tokens = Tokenizer.tokenize('!@#first//second third testing İcing Øscar')
+    string = '!first//second third testing İcing Øscar'
+    
+    scrubbed = Tokenizer.scrub(string)
+    assert scrubbed == 'first second third testing icing oscar'
+
+    tokens = Tokenizer.tokenize(string)
     assert tokens == ['first', 'second', 'third', 'test', 'ice', 'oscar']


### PR DESCRIPTION
`dlx.util.Tokenizer` was splitting on any char matching regex `\W`. This was causing splits on some unintended diacritic-related characters 