### PR TITLE
Exception handling

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -686,7 +686,10 @@ class Marc(object):
                 self.created = previous_state['created']
                 self.created_user = previous_state['created_user']
             else:
-                raise Exception(f'Created date not found for existing record {self.record_type} {self.id}')
+                # the record is likely from the legacy system (inserted directly into DB, hence no audit data)
+                #raise Exception(f'Created date not found for existing record {self.record_type} {self.id}')
+                self.created = None
+                self.created_user = None
         elif new_record:
             self.created = self.updated
             self.created_user = self.user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ def bibs():
     return [
         {
             '_id': 1,
-            'created': datetime.now(),
-            'created_user': 'admin',
+            #'created': datetime.now(),
+            #'created_user': 'admin',
             '000': ['leader'],
             '008': ['controlfield'],
             '245': [
@@ -44,8 +44,8 @@ def bibs():
         },
         {
             '_id': 2,
-            'created': datetime.now(),
-            'created_user': 'admin',
+            #'created': datetime.now(),
+            #'created_user': 'admin',
             '000': ['leader'],
             '245': [
                 {
@@ -67,8 +67,8 @@ def auths():
     return [
         {
             '_id': 1,
-            'created': datetime.now(),
-            'created_user': 'admin',
+            #'created': datetime.now(),
+            #'created_user': 'admin',
             '150': [
                 {
                     'indicators': [' ', ' '],
@@ -78,8 +78,8 @@ def auths():
         },
         {
             '_id': 2,
-            'created': datetime.now(),
-            'created_user': 'admin',
+            #'created': datetime.now(),
+            #'created_user': 'admin',
             '110': [
                 {
                     'indicators' : [' ', ' '],


### PR DESCRIPTION
Don't raise exception if records do not have create date on commit. Records that were inserted directly into the database from the legacy system do not have creation data