### PR TITLE
don't check inds when checking if auth heading has changed

### DIFF
--- a/dlx/config.py
+++ b/dlx/config.py
@@ -316,7 +316,19 @@ class Config():
             r += [t for t in code.values()]
         
         return list(set(r))
-    
+
+    @staticmethod
+    def auth_linked_codes(heading_tag):
+        # returns the subfield codes that can be linked to for the given auth heading tag
+        codes = []
+
+        for tag, subdict in list(Config.bib_authority_controlled.items()) + list(Config.auth_authority_controlled.items()):
+            for code, tag in subdict.items():
+                if tag == heading_tag:
+                    codes.append(code)
+
+        return [str(x) for x in codes]
+            
     @staticmethod
     def language_source_tag(tag, language):
         tags = Config.auth_language_tag

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -931,11 +931,16 @@ class Marc(object):
                     LOGGER.exception(err)
 
             if isinstance(self, Auth) and update_attached == True:
-                if previous_state: 
+                if previous_state:
+                    # only update attached record if the heading field changed
+                    # don't check indicators
                     previous = Auth(previous_state)
+                    linked_codes = Config.auth_linked_codes(self.heading_field.tag)
+                    heading_serialized = [(x.code, x.value) for x in list(filter(lambda x: x.code in linked_codes, self.heading_field.subfields))]
+                    prev_serialized = [(x.code, x.value) for x in list(filter(lambda x: x.code in linked_codes, previous.heading_field.subfields))]
 
-                    if self.heading_field.to_mrk() != previous.heading_field.to_mrk():
-                        # only update attached record if the heading field changed
+                    if heading_serialized != prev_serialized:
+                        # the heading has changed
                         if DB.database_name == 'testing': 
                             update_attached_records(self)
                         else:


### PR DESCRIPTION
Don't check indicators when determining whether to update records attached to a saved auth record