### PR TITLE
Use field object to delete field instaed of element index

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -660,7 +660,7 @@ class Marc(object):
     def delete_field(self, tag_or_field, place=0):
         if isinstance(tag_or_field, (Controlfield, Datafield)):
             field = tag_or_field
-            del self.fields[self.fields.index(field)]
+            self.fields = [f for f in self.fields if f != field]
         elif isinstance(place, int):
             tag = tag_or_field
             i, j = 0, 0
@@ -669,8 +669,7 @@ class Marc(object):
                 if field.tag == tag:
                     if j == place:
                         del self.fields[i]
-
-                        return
+                        return self
 
                     j += 1
         else:

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -582,6 +582,11 @@ def test_delete_field(bibs):
     bib.delete_field('520', place=1)
     assert len(list(bib.get_fields('520'))) == 1
     assert bib.get_values('520', 'a') == ['Description']
+
+    # delete using field object
+    field = bib.get_field('520')
+    bib.delete_field(field)
+    assert bib.get_fields('520') == []
     
 def test_auth_lookup(db):
     from dlx.marc import Bib, Auth


### PR DESCRIPTION
Bugfix in `Marc.delete_field()` when using a field object as the argument. Closes #301