### PR TITLE
Table serialization (CSV AND TSV)

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -303,6 +303,24 @@ class MarcSet():
     def to_excel(self, path):
         pass
 
+    def to_table(self) -> Table:
+        table = Table()
+
+        for i, record in enumerate(self.records):
+            i += 1
+
+            for tag in [x for x in record.get_tags() if not re.match('00', x)]:
+                for place, field in enumerate(record.get_fields(tag)):
+                    place += 1
+
+                    for subfield in field.subfields:
+                        table.set(i, f'{place}.{field.tag}${subfield.code}', subfield.value)
+
+        return table
+
+    def to_csv(self) -> str:
+        return self.to_table().to_csv()
+
 class BibSet(MarcSet):
     def __init__(self, *args, **kwargs):
         self.handle = DB.bibs

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -320,6 +320,9 @@ class MarcSet():
 
     def to_csv(self) -> str:
         return self.to_table().to_csv()
+    
+    def to_tsv(self) -> str:
+        return self.to_table().to_tsv()
 
 class BibSet(MarcSet):
     def __init__(self, *args, **kwargs):

--- a/dlx/util.py
+++ b/dlx/util.py
@@ -115,8 +115,9 @@ class Table():
             for field in self.header:
                 if value := record.get(field):
                     if separator in value:
-                        # todo: escape the separator
-                        pass    
+                        # handle the separator
+                        value.replace('"', '""')
+                        value = f'"{value}"'
                     
                     row.append(value)
                 else:

--- a/dlx/util.py
+++ b/dlx/util.py
@@ -38,18 +38,19 @@ class Table():
             
         return cls(lol)
         
-    def __init__(self,list_of_lists=None,**kwargs):
-        self.index = {}
-        self.header = []
+    def __init__(self, list_of_lists=None, **kwargs):
+        self.index = {} # data structure that stores the table
+        self.header = [] # list of field names for the header
         
+        # todo: put this in a class method that instantiates the object
         if list_of_lists:
             self.header = list_of_lists[0]
-            
             rowx = 0
+
             for row in list_of_lists[1:len(list_of_lists)]:
                 self.index[rowx] = {}
-                
                 cellx = 0
+
                 for cell in row:
                     field_name = self.header[cellx]
                     self.index[rowx][field_name] = cell
@@ -57,9 +58,14 @@ class Table():
                 
                 rowx += 1
                 
-    def set(self,rowx,field_name,value):
+    def set(self, rowx, field_name, value):
+        self.index.setdefault(rowx, {})
+        self.index[rowx].setdefault(field_name, {})
         self.index[rowx][field_name] = value
-        
+
+        if field_name not in self.header:
+            self.header.append(field_name)
+
         return self 
         
     def get(self,rowx,field_name):
@@ -80,6 +86,7 @@ class Table():
         return output
         
     def to_html(self,**kwargs):
+        # todo: refactor
         rows = []
         
         for row in self.to_list():
@@ -93,7 +100,23 @@ class Table():
         table = f'<table>{to_str}</table>'
         
         return table
+    
+    def to_csv(self):
+        rows = [self.header]
+
+        for i, record in self.index.items():
+            row = []
         
+            for field in self.header:
+                if value := record.get(field):
+                    row.append(value)
+                else:
+                    row.append('')
+            
+            rows.append(row)
+
+        return '\n'.join([','.join(row) for row in rows])
+
 class ISO6391():
     codes = {    
         "aa": "Afar",

--- a/dlx/util.py
+++ b/dlx/util.py
@@ -101,7 +101,12 @@ class Table():
         
         return table
     
-    def to_csv(self):
+    def serialize(self, *, separator):
+        valid = (',', '\t')
+
+        if separator not in valid:
+            raise Exception(f'Separator must be in {valid}')
+        
         rows = [self.header]
 
         for i, record in self.index.items():
@@ -109,13 +114,23 @@ class Table():
         
             for field in self.header:
                 if value := record.get(field):
+                    if separator in value:
+                        # todo: escape the separator
+                        pass    
+                    
                     row.append(value)
                 else:
                     row.append('')
             
             rows.append(row)
 
-        return '\n'.join([','.join(row) for row in rows])
+        return '\n'.join([separator.join(row) for row in rows])
+    
+    def to_csv(self):
+        return self.serialize(separator=',')
+    
+    def to_tsv(self):
+        return self.serialize(separator='\t')
 
 class ISO6391():
     codes = {    

--- a/tests/test_marcset.py
+++ b/tests/test_marcset.py
@@ -162,6 +162,12 @@ def test_to_str(db):
     control = '000\n   leader\n008\n   controlfield\n245\n   a: This\n   b: is the\n   c: title\n520\n   a: Description\n520\n   a: Another description\n   a: Repeated subfield\n650\n   a: Header\n710\n   a: Another header\n\n000\n   leader\n245\n   a: Another\n   b: is the\n   c: title\n650\n   a: Header\n'
     assert BibSet.from_query({}).to_str() == control
 
+def test_to_csv(db):
+    from dlx.marc import BibSet
+
+    bibset = BibSet.from_query({})
+    assert bibset.to_csv() == '1.245$a,1.245$b,1.245$c,1.520$a,2.520$a,1.650$a,1.710$a\nThis,is the,title,Description,Repeated subfield,Header,Another header\nAnother,is the,title,,,Header,'
+
 def test_from_aggregation(db, bibs):
     from dlx.marc import BibSet, Query
 


### PR DESCRIPTION
Implements `MarcSet.to_table()` and `Table.serialize()`. Recognized table separators are "," and "\t"

Closes #274