### PR TITLE
Fix 001

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -336,10 +336,10 @@ class MarcSet():
 
         return table
 
-    def to_csv(self, *, write_id=False) -> str:
+    def to_csv(self, *, write_id=True) -> str:
         return self.to_table(write_id=write_id).to_csv()
     
-    def to_tsv(self, *, write_id=False) -> str:
+    def to_tsv(self, *, write_id=True) -> str:
         return self.to_table(write_id=write_id).to_tsv()
 
 class BibSet(MarcSet):
@@ -1235,7 +1235,7 @@ class Marc(object):
 
         return json.dumps(mij)
 
-    def to_mrc(self, *tags, language=None, write_id=False):
+    def to_mrc(self, *tags, language=None, write_id=True):
         record = copy.deepcopy(self)
 
         if write_id:
@@ -1277,7 +1277,7 @@ class Marc(object):
 
         return new_leader + directory + data
 
-    def to_mrk(self, *tags, language=None, write_id=False):
+    def to_mrk(self, *tags, language=None, write_id=True):
         record = copy.deepcopy(self) # so as not to alter the original object's data
 
         if write_id:
@@ -1305,7 +1305,7 @@ class Marc(object):
 
         return string
 
-    def to_xml_raw(self, *tags, language=None, xref_prefix='', write_id=False):
+    def to_xml_raw(self, *tags, language=None, xref_prefix='', write_id=True):
         record = copy.deepcopy(self) # so as not to alter the orginal object's underlying data
 
         if write_id:
@@ -1352,8 +1352,8 @@ class Marc(object):
 
         return root
 
-    def to_xml(self, *tags, language=None, xref_prefix=''):
-        return ElementTree.tostring(self.to_xml_raw(language=language, xref_prefix=xref_prefix), encoding='utf-8').decode('utf-8')
+    def to_xml(self, *tags, language=None, xref_prefix='', write_id=True):
+        return ElementTree.tostring(self.to_xml_raw(write_id= write_id, language=language, xref_prefix=xref_prefix), encoding='utf-8').decode('utf-8')
 
     def to_jmarcnx(self):
         xrec = type(self)()

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -276,16 +276,16 @@ class MarcSet():
 
     # serializations
 
-    def to_mrc(self, *, write_id=False):
+    def to_mrc(self, *, write_id=True):
         # todo: stream instead of queue in memory
         mrc = ''
 
         for record in self.records:
-            mrc += record.to_mrc()
+            mrc += record.to_mrc(write_id=write_id)
 
         return mrc
 
-    def to_xml(self, *, xref_prefix='', write_id=False):
+    def to_xml(self, *, xref_prefix='', write_id=True):
         # todo: stream instead of queue in memory
         root = ElementTree.Element('collection')
 
@@ -294,8 +294,8 @@ class MarcSet():
 
         return ElementTree.tostring(root, encoding='utf-8').decode('utf-8')
 
-    def to_mrk(self, *, write_id=False):
-        return '\n'.join([r.to_mrk() for r in self.records])
+    def to_mrk(self, *, write_id=True):
+        return '\n'.join([r.to_mrk(write_id=write_id) for r in self.records])
         
     def to_str(self):
         return '\n'.join([r.to_str() for r in self.records])
@@ -303,7 +303,7 @@ class MarcSet():
     def to_excel(self, path):
         pass
 
-    def to_table(self, *, write_id=False) -> Table:
+    def to_table(self, *, write_id=True) -> Table:
         table = Table()
 
         for i, record in enumerate(self.records):

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -646,7 +646,7 @@ def test_to_xml(db):
     from dlx.marc import Bib
     from xmldiff import main
     
-    control = '<record><controlfield tag="000">leader</controlfield><controlfield tag="008">controlfield</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">This</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Description</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Another description</subfield><subfield code="a">Repeated subfield</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield><datafield ind1=" " ind2=" " tag="710"><subfield code="a">Another header</subfield><subfield code="0">2</subfield></datafield></record>'
+    control = '<record><controlfield tag="000">leader</controlfield><controlfield tag="001">1</controlfield><controlfield tag="008">controlfield</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">This</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Description</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Another description</subfield><subfield code="a">Repeated subfield</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield><datafield ind1=" " ind2=" " tag="710"><subfield code="a">Another header</subfield><subfield code="0">2</subfield></datafield></record>'
     bib = Bib.find_one({'_id': 1})
     assert main.diff_texts(bib.to_xml(), control) == []
     
@@ -656,12 +656,12 @@ def test_xml_encoding():
     
     bib = Bib().set('245', 'a', 'Title with an é')
     control = f'<record><datafield ind1=" " ind2=" " tag="245"><subfield code="a">Title with an é</subfield></datafield></record>'
-    assert main.diff_texts(bib.to_xml(), control) == []
+    assert main.diff_texts(bib.to_xml(write_id=False), control) == []
     
 def test_to_mrc(db):
     from dlx.marc import Bib, Auth
     
-    control = '00224r|||a2200097|||4500008001300000245002400013520001600037520004300053650001100096710001900107\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faHeader\x1e  \x1faAnother header\x1e\x1d'
+    control = '00238r|||a2200109|||4500001000200000008001300002245002400015520001600039520004300055650001100098710001900109\x1e1\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faHeader\x1e  \x1faAnother header\x1e\x1d'
 
     bib = Bib.find_one({'_id': 1})
     assert bib.to_mrc() == control
@@ -669,15 +669,15 @@ def test_to_mrc(db):
     control = '00049||||a2200037|||4500150001100000\x1e  \x1faHeader\x1e\x1d'
    
     auth = Auth.find_one({'_id': 1})
-    assert auth.to_mrc() == control
+    assert auth.to_mrc(write_id=False) == control
     
     auth.set('994', 'a', 'Titulo').commit()
-    assert bib.to_mrc(language='es') == '00224r|||a2200097|||4500008001300000245002400013520001600037520004300053650001100096710001900107\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faTitulo\x1e  \x1faAnother header\x1e\x1d'
+    assert bib.to_mrc(language='es', write_id=False) == '00224r|||a2200097|||4500008001300000245002400013520001600037520004300053650001100096710001900107\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faTitulo\x1e  \x1faAnother header\x1e\x1d'
 
 def test_to_mrk(bibs):
     from dlx.marc import Bib
     
-    control = '=000  leader\n=008  controlfield\n=245  \\\\$aThis$bis the$ctitle\n=520  \\\\$aDescription\n=520  \\\\$aAnother description$aRepeated subfield\n=650  \\\\$aHeader$01\n=710  \\\\$aAnother header$02\n'
+    control = '=000  leader\n=001  1\n=008  controlfield\n=245  \\\\$aThis$bis the$ctitle\n=520  \\\\$aDescription\n=520  \\\\$aAnother description$aRepeated subfield\n=650  \\\\$aHeader$01\n=710  \\\\$aAnother header$02\n'
 
     bib = Bib.find_one({'_id': 1})
     assert bib.to_mrk() == control

--- a/tests/test_marcset.py
+++ b/tests/test_marcset.py
@@ -130,20 +130,20 @@ def test_from_xml(db):
 def test_to_mrc(db):
     from dlx.marc import BibSet
     
-    control = '00224r|||a2200097|||4500008001300000245002400013520001600037520004300053650001100096710001900107\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faHeader\x1e  \x1faAnother header\x1e\x1d00088r|||a2200049|||4500245002700000650001100027\x1e  \x1faAnother\x1fbis the\x1fctitle\x1e  \x1faHeader\x1e\x1d'
+    control = '00238r|||a2200109|||4500001000200000008001300002245002400015520001600039520004300055650001100098710001900109\x1e1\x1econtrolfield\x1e  \x1faThis\x1fbis the\x1fctitle\x1e  \x1faDescription\x1e  \x1faAnother description\x1faRepeated subfield\x1e  \x1faHeader\x1e  \x1faAnother header\x1e\x1d00102r|||a2200061|||4500001000200000245002700002650001100029\x1e2\x1e  \x1faAnother\x1fbis the\x1fctitle\x1e  \x1faHeader\x1e\x1d'
     assert BibSet.from_query({}).to_mrc() == control
     
 def test_to_mrk(db):
     from dlx.marc import BibSet
     
-    control = '=000  leader\n=008  controlfield\n=245  \\\\$aThis$bis the$ctitle\n=520  \\\\$aDescription\n=520  \\\\$aAnother description$aRepeated subfield\n=650  \\\\$aHeader$01\n=710  \\\\$aAnother header$02\n\n=000  leader\n=245  \\\\$aAnother$bis the$ctitle\n=650  \\\\$aHeader$01\n'
+    control = '=000  leader\n=001  1\n=008  controlfield\n=245  \\\\$aThis$bis the$ctitle\n=520  \\\\$aDescription\n=520  \\\\$aAnother description$aRepeated subfield\n=650  \\\\$aHeader$01\n=710  \\\\$aAnother header$02\n\n=000  leader\n=001  2\n=245  \\\\$aAnother$bis the$ctitle\n=650  \\\\$aHeader$01\n'
     assert BibSet.from_query({}).to_mrk() == control
     
 def test_to_xml(db):
     from dlx.marc import BibSet
     from xmldiff import main
     
-    control = '<collection><record><controlfield tag="000">leader</controlfield><controlfield tag="008">controlfield</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">This</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Description</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Another description</subfield><subfield code="a">Repeated subfield</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield><datafield ind1=" " ind2=" " tag="710"><subfield code="a">Another header</subfield><subfield code="0">2</subfield></datafield></record><record><controlfield tag="000">leader</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">Another</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield></record></collection>'
+    control = '<collection><record><controlfield tag="000">leader</controlfield><controlfield tag="001">1</controlfield><controlfield tag="008">controlfield</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">This</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Description</subfield></datafield><datafield ind1=" " ind2=" " tag="520"><subfield code="a">Another description</subfield><subfield code="a">Repeated subfield</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield><datafield ind1=" " ind2=" " tag="710"><subfield code="a">Another header</subfield><subfield code="0">2</subfield></datafield></record><record><controlfield tag="000">leader</controlfield><controlfield tag="001">2</controlfield><datafield ind1=" " ind2=" " tag="245"><subfield code="a">Another</subfield><subfield code="b">is the</subfield><subfield code="c">title</subfield></datafield><datafield ind1=" " ind2=" " tag="650"><subfield code="a">Header</subfield><subfield code="0">1</subfield></datafield></record></collection>'
     assert main.diff_texts(BibSet.from_query({}).to_xml(), control) == []
     
 def test_xml_encoding():
@@ -154,7 +154,7 @@ def test_xml_encoding():
     control = f'<collection><record><datafield ind1=" " ind2=" " tag="245"><subfield code="a">Title with an é</subfield></datafield></record></collection>'
     bibset = BibSet()
     bibset.records = [bib]
-    assert main.diff_texts(bibset.to_xml(), control) == []
+    assert main.diff_texts(bibset.to_xml(write_id=False), control) == []
      
 def test_to_str(db):
     from dlx.marc import BibSet


### PR DESCRIPTION
Ensure 001 is written to records in `MarcSet.to_mrk` and write id to 001 by default in xml, mrk, mrc. Addresses dlx-rest. Adresses https://github.com/dag-hammarskjold-library/dlx-rest/issues/1507