### PR TITLE
Auth.resolve_ambguous

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -1605,7 +1605,7 @@ class Auth(Marc):
         return xrefs
 
     @classmethod
-    def resolve_ambiguous(cls, *, tag: str, subfields: list, record_type: str) -> int | None:
+    def resolve_ambiguous(cls, *, tag: str, subfields: list, record_type: str) -> int:
         '''Determines if there is an exact authority match for specific subfields'''
 
         subfields_str = str([(x.code, x.value) for x in subfields])

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -1603,8 +1603,7 @@ class Auth(Marc):
         query = Query(Condition(auth_tag, dict(zip([x.code for x in subfields], [x.value for x in subfields])), record_type='auth'))
         auths = AuthSet.from_query(query.compile(), projection={'_id': 1})
         xrefs = [r.id for r in list(auths)]
-
-        Auth._xcache.setdefault('multi', {}).setdefault(values, {})[auth_tag] = values
+        Auth._xcache.setdefault('multi', {}).setdefault(values, {})[auth_tag] = xrefs
 
         return xrefs
 

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -1595,7 +1595,7 @@ class Auth(Marc):
             return
 
         values = ''.join([x.value for x in subfields])
-        cached = Auth._xcache.get('multi', {}).get(values, {}).get(auth_tag, {})
+        cached = Auth._xcache.get('__multi__', {}).get(values, {}).get(auth_tag, {})
         
         if cached:
             return cached
@@ -1603,7 +1603,7 @@ class Auth(Marc):
         query = Query(Condition(auth_tag, dict(zip([x.code for x in subfields], [x.value for x in subfields])), record_type='auth'))
         auths = AuthSet.from_query(query.compile(), projection={'_id': 1})
         xrefs = [r.id for r in list(auths)]
-        Auth._xcache.setdefault('multi', {}).setdefault(values, {})[auth_tag] = xrefs
+        Auth._xcache.setdefault('__multi__', {}).setdefault(values, {})[auth_tag] = xrefs
 
         return xrefs
 

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -1628,7 +1628,6 @@ class Auth(Marc):
                     if [(x.code, x.value) for x in subfields] ==  auth_subfields:
                         exact_matches.append(xref)
 
-                if len(exact_matches) == 1:
                     Auth._acache.setdefault(subfields_str, exact_matches[0])
 
                     return exact_matches[0]

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -920,3 +920,21 @@ def test_list_attached(db, bibs, auths):
     assert len(auth.list_attached(usage_type='bib')) == 2
     assert auth.list_attached()[0].id == 1
     assert auth.list_attached()[1].id == 2
+
+def test_resolve_ambiguous(db):
+    from dlx.marc import Bib, Auth, AmbiguousAuthValue, Literal
+
+    auth = Auth().set('100', 'a', 'ambiguous').commit()
+    Auth().set('100', 'a', 'ambiguous').set('100', 'b', 'xyz').commit()
+
+    assert len(Auth.xlookup('700', 'a', 'ambiguous', record_type='bib')) == 2
+
+    xref = Auth.resolve_ambiguous(
+        tag='700', 
+        subfields=[Literal(code='a', value='ambiguous')],
+        record_type='bib'
+    )
+
+    assert xref == auth.id
+
+


### PR DESCRIPTION
Tool for determining if there is an auth heading where only the given subfields exist. Closes #365