### PR TITLE
Use nltk 3.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ lxml==5.2.1
 MarkupSafe==2.1.5
 mongomock==4.1.2
 moto==5.0.8
-nltk==3.9
+nltk==3.9.1
 packaging==24.0
 pluggy==1.5.0
 pycparser==2.22


### PR DESCRIPTION
Attempting to resolve https://github.com/nltk/nltk/issues/3308 which is causing nltk 3.9 to not be installable in the Github Actions environment