### PR TITLE
remove botocore from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 attrs==23.2.0
 boto3==1.35.45
-botocore==1.35.50
 certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2


### PR DESCRIPTION
Botocore is required by boto3 and is therefore installed when we install boto3. When processes like Dependabot update boto3 but not botocore, this causes our tests to fail because the versions are supposed to remain in sync. Removing this will not impact functionality but will improve maintainability.