### PR TITLE
Remove Python 3.8 from test matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.8 reached end of life in October 2024 and should be removed from our test matrices, since updated requirements will begin to drop support for it.

We should consider adding Python 3.13 to the test matrices, but that should be a separate PR.