### PR TITLE
Fix Auth.resolve_ambiguous args

### DIFF
--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -215,7 +215,7 @@ class MarcSet():
                 
                 # attempt to use multiple subfields to resolve ambiguity
                 if ambiguous:
-                    if xref := Auth.resolve_ambiguous(tag, ambiguous, record_type=self.record_type):
+                    if xref := Auth.resolve_ambiguous(tag=tag, subfields=ambiguous, record_type=self.record_type):
                         field.set(code, xref, place='+', auth_control=auth_control)
                     else:
                         exceptions.append(str(AmbiguousAuthValue(self.record_type, field.tag, '*', str([x.to_str() for x in ambiguous]))))
@@ -1486,10 +1486,10 @@ class Marc(object):
                 
                 # attempt to use multiple subfields to resolve ambiguity
                 if ambiguous:
-                    if xref := Auth.resolve_ambiguous(tag, ambiguous, record_type=self.record_type):
+                    if xref := Auth.resolve_ambiguous(tag=tag, subfields=ambiguous, record_type=self.record_type):
                         field.set(code, xref, place='+', auth_control=auth_control)
                     else:
-                        raise AmbiguousAuthValue(self.record_type, field.tag, '*', str([x.to_str() for x in ambiguous]))
+                        raise AmbiguousAuthValue(self.record_type, field.tag, '*', str([x.value for x in ambiguous]))
             
                 # remove subfield $0
                 if delete_subfield_zero:
@@ -1541,7 +1541,7 @@ class Marc(object):
 
                 # attempt to use multiple subfields to resolve ambiguity
                 if ambiguous:
-                    if xref := Auth.resolve_ambiguous(tag, ambiguous, record_type=self.record_type):
+                    if xref := Auth.resolve_ambiguous(tag=tag, subfields=ambiguous, record_type=self.record_type):
                         field.set(code, xref, auth_control=auth_control, place='+')
                     else:
                         raise AmbiguousAuthValue(self.record_type, tag, '*', str([x.to_str() for x in ambiguous]))


### PR DESCRIPTION
Some arguments were provided to Auth.resolve_ambiguous() that were postional arguments instead of keyword