### PR TITLE
Fix .delete_fields

### DIFF
--- a/dlx/file/__init__.py
+++ b/dlx/file/__init__.py
@@ -199,6 +199,7 @@ class File(object):
         checksum = hasher.hexdigest()    
         
         if overwrite == False:
+            # throws a FileExists exception (or one of its child exceptions) if the file is already in the system
             File._check_file_exists(checksum, identifiers, languages)
 
         handle.seek(0)

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -741,9 +741,12 @@ class Marc(object):
 
     def delete_field(self, tag_or_field, place=0):
         if isinstance(tag_or_field, (Controlfield, Datafield)):
+            # arg is a field
             field = tag_or_field
             self.fields = [f for f in self.fields if f != field]
+
         elif isinstance(place, int):
+            # arg is a tag
             tag = tag_or_field
             i, j = 0, 0
 
@@ -760,7 +763,7 @@ class Marc(object):
         return self
 
     def delete_fields(self, *tags):
-        self.fields = list(filter(lambda x: x.tag not in tags, self.datafields))
+        self.fields = list(filter(lambda x: x.tag not in tags, self.fields))
 
         return self
 

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -635,11 +635,16 @@ def test_set_008(bibs):
     assert bib.get_value('008')[7:11] == '1999'
     
 def test_delete_field(bibs):
+    import copy
     from dlx.marc import Bib
     
     bib = Bib.from_query({'_id': 1})
+    original = copy.deepcopy(bib)
+
     bib.delete_field('008')
-    assert list(bib.get_fields('008')) == []
+    assert len(bib.diff(original).b) == 1
+    assert bib.diff(original).b[0].tag == '008'
+
     bib.delete_field('500')
     assert list(bib.get_fields('500')) == []
     
@@ -651,6 +656,14 @@ def test_delete_field(bibs):
     field = bib.get_field('520')
     bib.delete_field(field)
     assert bib.get_fields('520') == []
+
+    # multi fields
+    bib.set('999', 'a', 'x').set('999', 'a', 'x', address='+')
+    original = copy.deepcopy(bib)
+    assert len(bib.get_fields('999')) == 2
+    bib.delete_fields('999')
+    assert len(bib.diff(original).b) == 2
+    assert all([x.tag == '999' for x in bib.diff(original).b])
     
 def test_auth_lookup(db):
     from dlx.marc import Bib, Auth


### PR DESCRIPTION
All controlfields were being deleted from the record in the .delete_fields method

Addresses https://github.com/dag-hammarskjold-library/batch-edits/issues/49