### PR TITLE
Field detection in search string tokenizer

### DIFF
--- a/dlx/marc/query.py
+++ b/dlx/marc/query.py
@@ -34,7 +34,7 @@ class Query():
             for i, char in enumerate(string):
                 buffer += char
 
-                if len(buffer) > 1 and buffer[-2:] == "':" and not in_single_quotes:
+                if char == "'" and re.match(r'^\w+:'):
                     in_single_quotes = True
                 elif char == "'":
                     in_single_quotes = False


### PR DESCRIPTION
Expands on attempts to make sure that colons are only interpreted as the field separator when appropriate