### PR TITLE
Add valkey support

### DIFF
--- a/dlx/db.py
+++ b/dlx/db.py
@@ -115,6 +115,8 @@ class DB():
         DB.files = DB.handle['files']
 
         if cache:
+            DB.cache = None
+
             # redis and valkey clients have the same interface so they can be treated the same
             assert isinstance(cache, (redis.Redis, valkey.Valkey))
             

--- a/dlx/db.py
+++ b/dlx/db.py
@@ -2,7 +2,7 @@
 Provides the DB class for connecting to and accessing the database.
 """
 
-import re, certifi, redis
+import re, certifi, redis, valkey
 from pymongo import MongoClient
 
 #from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
@@ -115,12 +115,14 @@ class DB():
         DB.files = DB.handle['files']
 
         if cache:
-            assert isinstance(cache, redis.Redis)
+            # redis and valkey clients have the same interface so they can be treated the same
+            assert isinstance(cache, (redis.Redis, valkey.Valkey))
             
             try:
+                # throws exception if the server is unavailable
                 cache.ping()
             except:
-                raise Exception(f'Unable to connect to Redis server: {cache}')
+                raise Exception(f'Unable to connect to cache server: {cache}')
             
             DB.cache = cache
 

--- a/dlx/marc/__init__.py
+++ b/dlx/marc/__init__.py
@@ -1121,6 +1121,7 @@ class Marc(object):
                 [data.setdefault(x.code, x.value) for x in hf.subfields]
 
                 if redis := DB.cache:
+                    key = f'authcache:{self.id}'  
                     redis[self.id] = json.dumps(data)
                 else:
                     Auth._cache.setdefault(self.id, data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ pytest==8.4.2
 redis==6.3.0
 requests>=2.32.2
 responses==0.25.8
+valkey==6.1.1
 xlrd==2.0.2
 xmldiff==2.7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,5 +115,10 @@ def db(bibs, auths) -> MockClient:
 
 @pytest.fixture
 def redis_client(request):
-    redis_client = fakeredis.FakeRedis()
+    redis_client = fakeredis.FakeValkey()
     return redis_client
+
+@pytest.fixture
+def valkey_client(request):
+    valkey_client = fakeredis.FakeValkey()
+    return valkey_client


### PR DESCRIPTION
Allows a valkey-py client to be used for auth cache