### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 APIs for performing ETL operations on MARC and file data
 
 ### Requirements:
-* Python 3.9+
+* Python 3.10+
 * Valid MongoDB connection string
 * AWS S3 credentials (file submission only)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data = {'dlx': ['schemas/jmarc.schema.json', 'schemas/jfile.schema.json']},
     test_suite = 'tests',
     install_requires = requirements,
-    python_requires = '>=3.9',
+    python_requires = '>=3.10,<=3.14',
     entry_points = {
         'console_scripts': [
             'excel-marc=dlx.scripts.excel_marc:run',


### PR DESCRIPTION
Python 3.9 is end of life and is preventing Pytest from being upgraded